### PR TITLE
Add mutex for volume creation/deletion.

### DIFF
--- a/pkg/csi/driver.go
+++ b/pkg/csi/driver.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -42,6 +43,7 @@ type Driver struct {
 	volumeTypeMap types.NamespacedName
 	driverName    string
 	driverVersion string
+	volMutex  sync.Mutex
 }
 
 var _ csi.IdentityServer = &Driver{}

--- a/pkg/csi/node.go
+++ b/pkg/csi/node.go
@@ -37,6 +37,9 @@ func (*Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabili
 }
 
 func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	d.volMutex.Lock()
+	defer d.volMutex.Unlock()
+
 	if len(req.GetTargetPath()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target path missing in request")
 	}
@@ -86,6 +89,9 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 }
 
 func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	d.volMutex.Lock()
+	defer d.volMutex.Unlock()
+
 	if len(req.GetTargetPath()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target path missing in request")
 	}


### PR DESCRIPTION
If a new node is created and multiple Pods are scheduled on it at the same time, there are race conditions on volume creation. This then leads to unrecoverable states of the volumes - resulting in no Pod being able to schedule.

Example: if two Pods are scheduled on a node, there might be two separate threads running at the same time to create the node volume. This could lead to one thread creating the RAID while the other is already passed that and formats that same volume.